### PR TITLE
doc missing 'places' declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ import { MatGoogleMapsAutocompleteModule } from '@angular-material-extensions/go
   declarations: [AppComponent, ...],
   imports: [
      AgmCoreModule.forRoot({
-          apiKey: 'YOUR_KEY'
+          apiKey: 'YOUR_KEY',
+          libraries: ['places']
         }),
      MatGoogleMapsAutocompleteModule.forRoot(), ...],  
   bootstrap: [AppComponent]


### PR DESCRIPTION
Added in readme   libraries: ['places'] in the main module declaration otherwise the adress completion will not work