### PR TITLE
fix: rxjs deep import

### DIFF
--- a/projects/angular-material-extensions/google-maps-autocomplete/src/lib/component/mat-search-google-maps-autocomplete/mat-search-google-maps-autocomplete.component.ts
+++ b/projects/angular-material-extensions/google-maps-autocomplete/src/lib/component/mat-search-google-maps-autocomplete/mat-search-google-maps-autocomplete.component.ts
@@ -6,7 +6,7 @@ import {GermanAddress} from '../../interfaces';
 import {Appearance} from '../mat-google-maps-autocomplete.component';
 import {InputAnimations} from '../../animations';
 import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
-import {Subject} from 'rxjs/internal/Subject';
+import {Subject} from 'rxjs';
 
 @Component({
   selector: 'mat-search-google-maps-autocomplete',


### PR DESCRIPTION
Fixes this warning:

```
Warning: Entry point '@angular-material-extensions/google-maps-autocomplete' contains deep imports into 'node_modules/rxjs/internal/Subject'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```