### PR TITLE
directive: use host listener for value changes

### DIFF
--- a/projects/angular-material-extensions/google-maps-autocomplete/src/lib/directives/mat-google-maps-autocomplete.directive.ts
+++ b/projects/angular-material-extensions/google-maps-autocomplete/src/lib/directives/mat-google-maps-autocomplete.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, EventEmitter, forwardRef, Inject, Input, NgZone, OnInit, Output, PLATFORM_ID} from '@angular/core';
+import {Directive, ElementRef, EventEmitter, forwardRef, HostListener, Inject, Input, NgZone, OnInit, Output, PLATFORM_ID} from '@angular/core';
 import {ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {MatValidateAddressDirective} from '../directives/address-validator/mat-address-validator.directive';
 import {MapsAPILoader} from '@agm/core';
@@ -71,6 +71,11 @@ export class MatGoogleMapsAutocompleteDirective implements OnInit, ControlValueA
               public elemRef: ElementRef,
               public mapsAPILoader: MapsAPILoader,
               private ngZone: NgZone) {
+  }
+
+  @HostListener('input', ['$event'])
+  onInputChange(event) {
+    this.onChange.emit(event?.target?.value);
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Per [this issue](https://github.com/angular-material-extensions/google-maps-autocomplete/issues/317) and also [this issue as well](https://github.com/angular-material-extensions/google-maps-autocomplete/issues/301).

After 4.0.0 this project started using `NG_VALUE_ACCESSOR` to emit events on the input. This causes it to only emit on places update. I think there is a lot of value in emit changes on the input as many use this as both a search and an answer. 

Meaning this will allow users to type in the first part of an address _without_ selecting a place. 